### PR TITLE
Update parse_opt() in export.py to work as in train.py (#10789)

### DIFF
--- a/export.py
+++ b/export.py
@@ -610,7 +610,7 @@ def run(
     return f  # return list of exported files/dirs
 
 
-def parse_opt():
+def parse_opt(known=False):
     parser = argparse.ArgumentParser()
     parser.add_argument('--data', type=str, default=ROOT / 'data/coco128.yaml', help='dataset.yaml path')
     parser.add_argument('--weights', nargs='+', type=str, default=ROOT / 'yolov5s.pt', help='model.pt path(s)')
@@ -638,7 +638,7 @@ def parse_opt():
         nargs='+',
         default=['torchscript'],
         help='torchscript, onnx, openvino, engine, coreml, saved_model, pb, tflite, edgetpu, tfjs, paddle')
-    opt = parser.parse_args()
+    opt = parser.parse_known_args()[0] if known else parser.parse_args()
     print_args(vars(opt))
     return opt
 


### PR DESCRIPTION
Update parse_opt() to work as in train.py

Change parse_opt() be able to use parse_known_args(), same as in train.py, so export.main() can be called from other script without error.

e.g.:

    from yolov5 import export
    opt = export.parse_opt(True)
    opt.weights = <model_path>
    opt.include = ("torchscript", "onnx")
    opt.data = <data>
    opt.imgsz = [<height>, <width>]
    export.main(opt)



Signed-off-by: Johan Bergman <35481994+duran67@users.noreply.github.com>

Signed-off-by: Johan Bergman <35481994+duran67@users.noreply.github.com>

<!--
Thank you for submitting a YOLOv5 🚀 Pull Request! We want to make contributing to YOLOv5 as easy and transparent as possible. A few tips to get you started:

- Search existing YOLOv5 [PRs](https://github.com/ultralytics/yolov5/pull) to see if a similar PR already exists.
- Link this PR to a YOLOv5 [issue](https://github.com/ultralytics/yolov5/issues) to help us understand what bug fix or feature is being implemented.
- Provide before and after profiling/inference/training results to help us quantify the improvement your PR provides (if applicable).

Please see our ✅ [Contributing Guide](https://github.com/ultralytics/yolov5/blob/master/CONTRIBUTING.md) for more details.
-->
